### PR TITLE
(fix) Append on bytes in DataArray.to_bytes

### DIFF
--- a/dlms_cosem/dlms_data.py
+++ b/dlms_cosem/dlms_data.py
@@ -76,7 +76,7 @@ class DataArray(BaseDlmsData):
     def to_bytes(self) -> bytes:
         out = bytearray()
         out.append(self.TAG)
-        out.append(encode_variable_integer(len(self.value)))
+        out.extend(encode_variable_integer(len(self.value)))
         for item in self.value:
             out.extend(item.to_bytes())
         return bytes(out)


### PR DESCRIPTION
Error when creating data from DlmsData. Function returns bytes and not an int so should have been extend instead of append.

Fixes #73